### PR TITLE
fix refactor of repo code scanning alerts

### DIFF
--- a/main.py
+++ b/main.py
@@ -74,10 +74,10 @@ if __name__ == "__main__":
         secret_scanning.write_org_secrets_list(secrets_list)
     elif report_scope == "repository":
         # code scanning
-        cs_list = code_scanning.list_code_scanning_alerts(
+        cs_list = code_scanning.list_repo_code_scanning_alerts(
             api_endpoint, github_pat, scope_name
         )
-        cs_csv = code_scanning.write_cs_list(cs_list)
+        cs_csv = code_scanning.write_repo_cs_list(cs_list)
         # secret scanning
         secrets_list = secret_scanning.get_repo_secret_scanning_alerts(
             api_endpoint, github_pat, scope_name


### PR DESCRIPTION
Fix this error on running on a repo

```
Traceback (most recent call last):
  File "/app/main.py", line [7](https://github.com/some-natalie/ghas-data/runs/7080536881?check_suite_focus=true#step:4:8)7, in <module>
    cs_list = code_scanning.list_code_scanning_alerts(
AttributeError: module 'src.code_scanning' has no attribute 'list_code_scanning_alerts'. Did you mean: 'list_org_code_scanning_alerts'?
```