### PR TITLE
Add CVSS score column in Dependabot Alert List

### DIFF
--- a/src/dependabot.py
+++ b/src/dependabot.py
@@ -72,6 +72,7 @@ def write_repo_dependabot_list(dependabot_list):
                 "severity",
                 "ghsa_id",
                 "cve_id",
+                "cvss_score",
             ]
         )
         for alert in dependabot_list:
@@ -103,5 +104,6 @@ def write_repo_dependabot_list(dependabot_list):
                     alert["security_vulnerability"]["severity"],
                     alert["security_advisory"]["ghsa_id"],
                     alert["security_advisory"]["cve_id"],
+                    alert["security_advisory"]["cvss"]["score"],
                 ]
             )


### PR DESCRIPTION
Hi 👋 . How do you think about adding `cvss_score` column? I believe it's one good attribute to review, in addition to the standard `severity` (critical, high, etc.).

### Note

- Some of the alerts don't have CVSS scores, but the API returns the score as `0.0`.

### Example dependabot_list.csv (Excerpt)

```
number,state,created_at,updated_at,fixed_at,dismissed_at,dismissed_by,dismissed_reason,html_url,dependency_manifest,dependency_ecosystem,dependency_name,severity,ghsa_id,cve_id,cvss_score
26,fixed,2022-12-11T10:58:29Z,2022-12-11T11:25:12Z,2022-12-11T11:25:12Z,none,none,none,https://github.com/xxx/yyy/security/dependabot/26,yarn.lock,npm,qs,high,GHSA-hrpp-h998-j3pp,CVE-2022-24999,7.5
25,fixed,2022-12-11T10:58:29Z,2022-12-11T11:25:12Z,2022-12-11T11:25:12Z,none,none,none,https://github.com/xxx/yyy/security/dependabot/25,yarn.lock,npm,express,high,GHSA-hrpp-h998-j3pp,CVE-2022-24999,7.5
...
16,fixed,2022-09-08T04:48:47Z,2022-12-11T11:25:11Z,2022-12-11T11:25:11Z,none,none,none,https://github.com/xxx/yyy/security/dependabot/16,yarn.lock,npm,mongodb-query-parser,high,GHSA-hxmg-hm46-cf62,CVE-2020-24391,0.0
15,fixed,2022-09-08T04:48:47Z,2022-12-11T11:25:11Z,2022-12-11T11:25:11Z,none,none,none,https://github.com/xxx/yyy/security/dependabot/15,yarn.lock,npm,mongodb-query-parser,critical,GHSA-97mg-3cr6-3x4c,,0.0
```

### Reference
- [GitHub Docs - List Dependabot alerts for a repository](https://docs.github.com/en/rest/dependabot/alerts?apiVersion=2022-11-28#list-dependabot-alerts-for-a-repository)

```
        "cvss": {
            "type": "object",
            "description": "Details for the advisory pertaining to the Common Vulnerability Scoring System.",
            "readOnly": true,
            "properties": {
              "score": {
                "type": "number",
                "description": "The overall CVSS score of the advisory.",
                "minimum": 0,
                "maximum": 10,
                "readOnly": true
              },
              "vector_string": {
                "type": [
                  "string",
                  "null"
                ],
                "description": "The full CVSS vector string for the advisory.",
                "readOnly": true
              }
            },
            "required": [
              "score",
              "vector_string"
            ],
            "additionalProperties": false
          },
```