### PR TITLE
Add org-level / enterprise-level dependabot alert list

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Or for an enterprise:
 | --- | --- | --- | --- | --- |
 | Secret scanning | :white_check_mark: Repo<br>:white_check_mark: Org<br>:white_check_mark: Enterprise |  :white_check_mark: Repo<br>:white_check_mark: Org<br>:white_check_mark: Enterprise | :white_check_mark: Repo<br>:x: Org<br>:x: Enterprise | [API docs](https://docs.github.com/en/enterprise-cloud@latest/rest/reference/secret-scanning) |
 | Code scanning |  :white_check_mark: Repo<br>:white_check_mark: Org<br>:white_check_mark: Enterprise | :white_check_mark: Repo<br>:white_check_mark: Org<br>:curly_loop: Enterprise |  :white_check_mark: Repo<br>:x: Org<br>:curly_loop: Enterprise | [API docs](https://docs.github.com/en/enterprise-cloud@latest/rest/reference/code-scanning) |
-| Dependabot | :white_check_mark: Repo<br>:x: Org<br>:x: Enterprise | :x: | :x: | [API docs](https://docs.github.com/en/enterprise-cloud@latest/rest/dependabot/alerts) |
+| Dependabot | :white_check_mark: Repo<br>:white_check_mark: Org<br>:white_check_mark: Enterprise | :x: | :x: | [API docs](https://docs.github.com/en/enterprise-cloud@latest/rest/dependabot/alerts) |
 
 :information_source:  All of this reporting requires either public repositories or a GitHub Advanced Security license.
 

--- a/main.py
+++ b/main.py
@@ -66,6 +66,14 @@ if __name__ == "__main__":
                 api_endpoint, github_pat, scope_name
             )
             code_scanning.write_enterprise_cloud_cs_list(cs_list)
+        # dependabot alerts
+        if enterprise.get_enterprise_version(api_endpoint) == "GHEC":
+            dependabot_list = dependabot.list_enterprise_dependabot_alerts(
+                api_endpoint, github_pat, scope_name
+            )
+            dependabot.write_org_or_enterprise_dependabot_list(dependabot_list)
+        else:
+            pass
 
     elif report_scope == "organization":
         # code scanning
@@ -73,6 +81,14 @@ if __name__ == "__main__":
             api_endpoint, github_pat, scope_name
         )
         code_scanning.write_org_cs_list(cs_list)
+        # dependabot alerts
+        if enterprise.get_enterprise_version(api_endpoint) == "GHEC":
+            dependabot_list = dependabot.list_org_dependabot_alerts(
+                api_endpoint, github_pat, scope_name
+            )
+            dependabot.write_org_or_enterprise_dependabot_list(dependabot_list)
+        else:
+            pass
         # secret scanning
         secrets_list = secret_scanning.get_org_secret_scanning_alerts(
             api_endpoint, github_pat, scope_name

--- a/src/dependabot.py
+++ b/src/dependabot.py
@@ -108,6 +108,7 @@ def write_repo_dependabot_list(dependabot_list):
                 ]
             )
 
+
 def list_org_dependabot_alerts(api_endpoint, github_pat, org_name):
     """
     Get a list of all dependabot alerts on a given organization.
@@ -179,7 +180,9 @@ def list_enterprise_dependabot_alerts(api_endpoint, github_pat, enterprise_slug)
         )
         response_json.extend(response.json())
 
-    print("Found {} dependabot alerts in {}".format(len(response_json), enterprise_slug))
+    print(
+        "Found {} dependabot alerts in {}".format(len(response_json), enterprise_slug)
+    )
 
     # Return dependabot alerts
     return response_json

--- a/src/dependabot.py
+++ b/src/dependabot.py
@@ -107,3 +107,159 @@ def write_repo_dependabot_list(dependabot_list):
                     alert["security_advisory"]["cvss"]["score"],
                 ]
             )
+
+def list_org_dependabot_alerts(api_endpoint, github_pat, org_name):
+    """
+    Get a list of all dependabot alerts on a given organization.
+
+    Inputs:
+    - API endpoint (for GHES/GHAE compatibility)
+    - PAT of appropriate scope
+    - Organization name
+
+    Outputs:
+    - List of _all_ dependency alerts on the organization
+    """
+
+    # Get dependabot alerts
+    url = "{}/orgs/{}/dependabot/alerts?per_page=100&page=1".format(
+        api_endpoint, org_name
+    )
+    response = requests.get(
+        url,
+        headers={
+            "Authorization": "token {}".format(github_pat),
+            "Accept": "application/vnd.github+json",
+        },
+    )
+    response_json = response.json()
+    while "next" in response.links.keys():
+        response = requests.get(
+            response.links["next"]["url"],
+            headers={"Authorization": "token {}".format(github_pat)},
+        )
+        response_json.extend(response.json())
+
+    print("Found {} dependabot alerts in {}".format(len(response_json), org_name))
+
+    # Return dependabot alerts
+    return response_json
+
+
+def list_enterprise_dependabot_alerts(api_endpoint, github_pat, enterprise_slug):
+    """
+    Get a list of all dependabot alerts on a given enterprise.
+
+    Inputs:
+    - API endpoint (for GHES/GHAE compatibility)
+    - PAT of appropriate scope
+    - Enterprise slug (enterprise name URL, documented below)
+        - https://docs.github.com/en/rest/reference/enterprise-admin
+
+    Outputs:
+    - List of _all_ dependency alerts on the enterprise
+    """
+
+    # Get dependabot alerts
+    url = "{}/enterprises/{}/dependabot/alerts?per_page=100&page=1".format(
+        api_endpoint, enterprise_slug
+    )
+    response = requests.get(
+        url,
+        headers={
+            "Authorization": "token {}".format(github_pat),
+            "Accept": "application/vnd.github+json",
+        },
+    )
+    response_json = response.json()
+    while "next" in response.links.keys():
+        response = requests.get(
+            response.links["next"]["url"],
+            headers={"Authorization": "token {}".format(github_pat)},
+        )
+        response_json.extend(response.json())
+
+    print("Found {} dependabot alerts in {}".format(len(response_json), enterprise_slug))
+
+    # Return dependabot alerts
+    return response_json
+
+
+def write_org_or_enterprise_dependabot_list(dependabot_list):
+    """
+    Write the list of dependabot alerts to a CSV file.
+
+    Inputs:
+    - List of dependabot alerts
+
+    Outputs:
+    - CSV file of dependabot alerts
+    """
+    with open("dependabot_list.csv", "w") as f:
+        writer = csv.writer(f)
+        writer.writerow(
+            [
+                "number",
+                "state",
+                "created_at",
+                "updated_at",
+                "fixed_at",
+                "dismissed_at",
+                "dismissed_by",
+                "dismissed_reason",
+                "html_url",
+                "dependency_manifest",
+                "dependency_ecosystem",
+                "dependency_name",
+                "severity",
+                "ghsa_id",
+                "cve_id",
+                "cvss_score",
+                "repo_name",
+                "repo_owner",
+                "repo_owner_type",
+                "repo_owner_isadmin",
+                "repo_url",
+                "repo_isfork",
+                "repo_isprivate",
+            ]
+        )
+        for alert in dependabot_list:
+            if alert["state"] == "open":
+                alert["fixed_at"] = "none"
+                alert["dismissed_by"] = "none"
+                alert["dismissed_at"] = "none"
+                alert["dismissed_reason"] = "none"
+            if alert["state"] == "dismissed":
+                alert["fixed_at"] = "none"
+            if alert["state"] == "fixed":
+                alert["dismissed_by"] = "none"
+                alert["dismissed_at"] = "none"
+                alert["dismissed_reason"] = "none"
+            writer.writerow(
+                [
+                    alert["number"],
+                    alert["state"],
+                    alert["created_at"],
+                    alert["updated_at"],
+                    alert["fixed_at"],
+                    alert["dismissed_at"],
+                    alert["dismissed_by"],
+                    alert["dismissed_reason"],
+                    alert["html_url"],
+                    alert["dependency"]["manifest_path"],
+                    alert["dependency"]["package"]["ecosystem"],
+                    alert["dependency"]["package"]["name"],
+                    alert["security_vulnerability"]["severity"],
+                    alert["security_advisory"]["ghsa_id"],
+                    alert["security_advisory"]["cve_id"],
+                    alert["security_advisory"]["cvss"]["score"],
+                    alert["repository"]["full_name"],
+                    alert["repository"]["owner"]["login"],
+                    alert["repository"]["owner"]["type"],
+                    alert["repository"]["owner"]["site_admin"],
+                    alert["repository"]["html_url"],
+                    str(alert["repository"]["fork"]),
+                    str(alert["repository"]["private"]),
+                ]
+            )


### PR DESCRIPTION
Hi 👋 . This PR tries to add org-level / enterprise-level dependabot alert list (related to #26, but also added enterprise-level one).

## Changes
- Export dependabot alerts when either of `GITHUB_REPORT_SCOPE: "organization"` or `GITHUB_REPORT_SCOPE: "enterprise"` is specified.
  - The following columns will be added compared with repository level alerts (tried to align with code scanning alerts)
      - repo_name
      - repo_owner
      - repo_owner_type
      - repo_owner_isadmin
      - repo_url
      - repo_isfork
      - repo_isprivate
- Apply same columns for organization / enterprise level alerts (as I couldn't find specific differences between organization / enterprice)
- Update README to change :x: with :white_check_mark: for organization/enterprise level dependabot alerts.

## References
- [GitHub Blog - Dependabot alerts enterprise-level REST API](https://github.blog/changelog/2022-11-01-dependabot-alerts-enterprise-level-rest-api/)
- [GitHub Blog - Dependabot alerts organizational-level REST API](https://github.blog/changelog/2022-10-18-dependabot-alerts-organizational-level-rest-api/)

## Tested Conditions
### Workflows

<details>
<summary>Organization Level</summary><div>

```yml
name: Export Security Alerts (Organization)

on: workflow_dispatch
jobs:
  export:
    name: Export Code Scanning Alerts
    runs-on: ubuntu-latest
    permissions:
      actions: read
      contents: read
      security-events: read
    steps:
      - name: Export CSV
        uses: parroty/ghas-to-csv@add-org-dependabot
        env:
          GITHUB_PAT: ${{ secrets.PAT }}
          GITHUB_REPORT_SCOPE: "organization"
          SCOPE_NAME: "xxx"
      - name: Upload CSV
        uses: actions/upload-artifact@v3
        with:
          name: ghas-data
          path: ${{ github.workspace }}/*.csv
          if-no-files-found: error
```

</div></details>

<details>
<summary>Enterprise Level</summary><div>

```yml
name: Export Security Alerts (Enterprise)

on: workflow_dispatch
jobs:
  export:
    name: Export Code Scanning Alerts
    runs-on: ubuntu-latest
    permissions:
      actions: read
      contents: read
      security-events: read
    steps:
      - name: Export CSV
        uses: parroty/ghas-to-csv@add-org-dependabot
        env:
          GITHUB_PAT: ${{ secrets.PAT }}
          GITHUB_REPORT_SCOPE: "enterprise"
          SCOPE_NAME: "xxx"
      - name: Upload CSV
        uses: actions/upload-artifact@v3
        with:
          name: ghas-data
          path: ${{ github.workspace }}/*.csv
          if-no-files-found: error
```

</div></details>

### Tested Conditions

- PAT (classic) with following scopes
  - `repo:security_events`
  - `read:org`
  - `read:enterprise`
- Condition with more than 100 alerts


### Exerpts (from Enteprise-Level)


**Actions Log**

```
Run parroty/ghas-to-csv@add-org-dependabot

...

Found 20 secret scanning alerts in xxx enterprise
Found 3 code scanning alerts in xxx
Found 151 dependabot alerts in xxx
```

**Command**

```
$ ls
cs_list.csv         dependabot_list.csv secrets_list.csv

$ wc -l dependabot_list.csv
     152 dependabot_list.csv

$ head -3 dependabot_list.csv
number,state,created_at,updated_at,fixed_at,dismissed_at,dismissed_by,dismissed_reason,html_url,dependency_manifest,dependency_ecosystem,dependency_name,severity,ghsa_id,cve_id,cvss_score,repo_name,repo_owner,repo_owner_type,repo_owner_isadmin,repo_url,repo_isfork,repo_isprivate
36,open,2022-12-13T13:28:20Z,2022-12-13T13:28:20Z,none,none,none,none,https://github.com/xxx/sample-ghas-4/security/dependabot/36,yarn.lock,npm,qs,high,GHSA-hrpp-h998-j3pp,CVE-2022-24999,7.5,xxx/sample-ghas-4,xxx,Organization,False,https://github.com/xxx/sample-ghas-4,False,True
35,open,2022-12-13T13:28:20Z,2022-12-13T13:28:20Z,none,none,none,none,https://github.com/xxx/sample-ghas-4/security/dependabot/35,yarn.lock,npm,express,high,GHSA-hrpp-h998-j3pp,CVE-2022-24999,7.5,xxx/sample-ghas-4,xxx,Organization,False,https://github.com/xxx/sample-ghas-4,False,True
```



