### PR TITLE
Ignore "excluded_repos.csv" for code scanning alerts of GitHub Enterprise Cloud

### DIFF
--- a/src/code_scanning.py
+++ b/src/code_scanning.py
@@ -445,7 +445,3 @@ def write_enterprise_cloud_cs_list(cs_list):
                     cs["instances_url"],
                 ]
             )
-        else:
-            with open("excluded_repos.csv", "a") as g:
-                writer = csv.writer(g)
-                writer.writerow([cs])


### PR DESCRIPTION
## Background
Hi 👋 . I just realized that enterprise-level code-scanning-alerts function generates `excluded_repos.csv` in an unexpected format (not CSV).

```
$ ls
cs_list.csv         dependabot_list.csv excluded_repos.csv  secrets_list.csv

$ head -c 100 excluded_repos.csv
"{'number': 1, 'created_at': '2022-12-13T14:34:38Z', 'updated_at': '2022-12-13T14:34:39Z', 'url': 'h
```

I am wondering that the `excluded_repos.csv` part is intended for `GitHub Enterprise Server` which requires multiple API calls per repository. But, it would not apply for `GitHub Enterprise Cloud` which can get the entire list with a single API call.

- https://github.com/some-natalie/ghas-to-csv/blob/main/main.py#L59
- https://github.com/some-natalie/ghas-to-csv/blob/main/src/code_scanning.py#L339

## Changes
- Remove `excluded_repos.csv` logic for `write_enterprise_cloud_cs_list` function.