### PR TITLE
performance: switch to object-based cursor from offset-based page cursors

### DIFF
--- a/src/code_scanning.py
+++ b/src/code_scanning.py
@@ -17,7 +17,7 @@ def list_repo_cs_alerts(api_endpoint, github_pat, repo_name):
     Outputs:
     - List of _all_ code scanning alerts on the repository
     """
-    url = f"{api_endpoint}/repos/{repo_name}/code-scanning/alerts?per_page=100&page=1"
+    url = f"{api_endpoint}/repos/{repo_name}/code-scanning/alerts?per_page=100&after="
     code_scanning_alerts = api_helpers.make_api_call(url, github_pat)
     print(f"Found {len(code_scanning_alerts)} code scanning alerts in {repo_name}")
     return code_scanning_alerts
@@ -104,7 +104,7 @@ def list_org_cs_alerts(api_endpoint, github_pat, org_name):
     - List of _all_ code scanning alerts on the organization
     """
 
-    url = f"{api_endpoint}/orgs/{org_name}/code-scanning/alerts?per_page=100&page=1"
+    url = f"{api_endpoint}/orgs/{org_name}/code-scanning/alerts?per_page=100&after="
     code_scanning_alerts = api_helpers.make_api_call(url, github_pat)
     print(f"Found {len(code_scanning_alerts)} code scanning alerts in {org_name}")
     return code_scanning_alerts
@@ -306,7 +306,7 @@ def list_enterprise_cloud_cs_alerts(api_endpoint, github_pat, enterprise_slug):
     - List of _all_ code scanning alerts in enterprise that PAT user can access
     """
 
-    url = f"{api_endpoint}/enterprises/{enterprise_slug}/code-scanning/alerts?per_page=100&page=1"
+    url = f"{api_endpoint}/enterprises/{enterprise_slug}/code-scanning/alerts?per_page=100&after="
     code_scanning_alerts = api_helpers.make_api_call(url, github_pat)
     print(f"Found {len(code_scanning_alerts)} code scanning alerts in {enterprise_slug}")
     return code_scanning_alerts

--- a/src/dependabot.py
+++ b/src/dependabot.py
@@ -17,7 +17,7 @@ def list_repo_dependabot_alerts(api_endpoint, github_pat, repo_name):
     Outputs:
     - List of _all_ dependency alerts on the repository
     """
-    url = f"{api_endpoint}/repos/{repo_name}/dependabot/alerts?per_page=100&page=1"
+    url = f"{api_endpoint}/repos/{repo_name}/dependabot/alerts?per_page=100&after="
     dependabot_alerts = api_helpers.make_api_call(url, github_pat)
     print(f"Found {len(dependabot_alerts)} dependabot alerts in {repo_name}")
     return dependabot_alerts
@@ -90,7 +90,7 @@ def list_org_dependabot_alerts(api_endpoint, github_pat, org_name):
     Outputs:
     - List of _all_ dependency alerts on the organization
     """
-    url = f"{api_endpoint}/orgs/{org_name}/dependabot/alerts?per_page=100&page=1"
+    url = f"{api_endpoint}/orgs/{org_name}/dependabot/alerts?per_page=100&after="
     dependabot_alerts = api_helpers.make_api_call(url, github_pat)
     print(f"Found {len(dependabot_alerts)} dependabot alerts in {org_name}")
     return dependabot_alerts
@@ -109,7 +109,7 @@ def list_enterprise_dependabot_alerts(api_endpoint, github_pat, enterprise_slug)
     Outputs:
     - List of _all_ dependency alerts on the enterprise
     """
-    url = f"{api_endpoint}/enterprises/{enterprise_slug}/dependabot/alerts?per_page=100&page=1"
+    url = f"{api_endpoint}/enterprises/{enterprise_slug}/dependabot/alerts?per_page=100&after="
     dependabot_alerts = api_helpers.make_api_call(url, github_pat)
     print(f"Found {len(dependabot_alerts)} dependabot alerts in {enterprise_slug}")
     return dependabot_alerts

--- a/src/secret_scanning.py
+++ b/src/secret_scanning.py
@@ -17,13 +17,13 @@ def get_repo_ss_alerts(api_endpoint, github_pat, repo_name):
     Outputs:
     - List of _all_ secret scanning alerts on the repository (both default and generic secret types)
     """
-    # First call: get default secret types (without any filters)
-    url_default = f"{api_endpoint}/repos/{repo_name}/secret-scanning/alerts?per_page=100&page=1"
+    # First call: get default secret types (without any filters), use after= to force object based cursor instead of page based
+    url_default = f"{api_endpoint}/repos/{repo_name}/secret-scanning/alerts?per_page=100&after="
     ss_alerts_default = api_helpers.make_api_call(url_default, github_pat)
 
-    # Second call: get generic secret types with hardcoded list
+    # Second call: get generic secret types with hardcoded list, use after= to force object based cursor instead of page based
     generic_secret_types = "password,http_basic_authentication_header,http_bearer_authentication_header,mongodb_connection_string,mysql_connection_string,openssh_private_key,pgp_private_key,postgres_connection_string,rsa_private_key"
-    url_generic = f"{api_endpoint}/repos/{repo_name}/secret-scanning/alerts?per_page=100&page=1&secret_type={generic_secret_types}"
+    url_generic = f"{api_endpoint}/repos/{repo_name}/secret-scanning/alerts?per_page=100&after=&secret_type={generic_secret_types}"
     ss_alerts_generic = api_helpers.make_api_call(url_generic, github_pat)
 
     # Combine results and deduplicate
@@ -114,14 +114,14 @@ def get_org_ss_alerts(api_endpoint, github_pat, org_name):
     Outputs:
     - List of _all_ secret scanning alerts on the organization (both default and generic secret types)
     """
-    # First call: get default secret types (without any filters)
-    url_default = f"{api_endpoint}/orgs/{org_name}/secret-scanning/alerts?per_page=100&page=1"
+    # First call: get default secret types (without any filters), use after= to force object based cursor instead of page based
+    url_default = f"{api_endpoint}/orgs/{org_name}/secret-scanning/alerts?per_page=100&after="
     ss_alerts_default = api_helpers.make_api_call(url_default, github_pat)
 
-    # Second call: get generic secret types with hardcoded list
+    # Second call: get generic secret types with hardcoded list, use after= to force object based cursor instead of page based
     generic_secret_types = "password,http_basic_authentication_header,http_bearer_authentication_header,mongodb_connection_string,mysql_connection_string,openssh_private_key,pgp_private_key,postgres_connection_string,rsa_private_key"
     url_generic = (
-        f"{api_endpoint}/orgs/{org_name}/secret-scanning/alerts?per_page=100&page=1&secret_type={generic_secret_types}"
+        f"{api_endpoint}/orgs/{org_name}/secret-scanning/alerts?per_page=100&after=&secret_type={generic_secret_types}"
     )
     ss_alerts_generic = api_helpers.make_api_call(url_generic, github_pat)
 
@@ -228,13 +228,13 @@ def get_enterprise_ss_alerts(api_endpoint, github_pat, enterprise_slug):
     Outputs:
     - List of _all_ secret scanning alerts on the enterprise (both default and generic secret types)
     """
-    # First call: get default secret types (without any filters)
-    url_default = f"{api_endpoint}/enterprises/{enterprise_slug}/secret-scanning/alerts?per_page=100&page=1"
+    # First call: get default secret types (without any filters), use after= to force object based cursor instead of page based
+    url_default = f"{api_endpoint}/enterprises/{enterprise_slug}/secret-scanning/alerts?per_page=100&after="
     ss_alerts_default = api_helpers.make_api_call(url_default, github_pat)
 
-    # Second call: get generic secret types with hardcoded list
+    # Second call: get generic secret types with hardcoded list, use after= to force object based cursor instead of page based
     generic_secret_types = "password,http_basic_authentication_header,http_bearer_authentication_header,mongodb_connection_string,mysql_connection_string,openssh_private_key,pgp_private_key,postgres_connection_string,rsa_private_key"
-    url_generic = f"{api_endpoint}/enterprises/{enterprise_slug}/secret-scanning/alerts?per_page=100&page=1&secret_type={generic_secret_types}"
+    url_generic = f"{api_endpoint}/enterprises/{enterprise_slug}/secret-scanning/alerts?per_page=100&after=&secret_type={generic_secret_types}"
     ss_alerts_generic = api_helpers.make_api_call(url_generic, github_pat)
 
     # Combine results and deduplicate


### PR DESCRIPTION
Improve [performance ](https://github.blog/changelog/2022-06-22-secret-scannings-rest-api-endpoints-now-support-cursor-based-pagination/) for large numbers of alerts - avoid potential 503 responses
- Also, page based endpoints are being shut down: https://github.blog/changelog/2025-09-23-upcoming-changes-to-github-dependabot-alerts-rest-api-offset-based-pagination-parameters-page-first-and-last/


Response header will now use object IDs:
```
Link: <https://api.github.com/organizations/###/secret-scanning/alerts?per_page=1&after=CAESBggBEgIIAioTCgwIwb6GxwYQwICyiQMQnZGNRP&secret_type=password>; rel="next"
```

Instead of page based:
```
Link: <https://api.github.com/organizations/###/secret-scanning/alerts?per_page=1&page=2>; rel="next", <https://api.github.com/organizations/###/secret-scanning/alerts?per_page=1&page=93323>; rel="last"
```

At least with dependabot, omitting the `after` empty param falls back to page number based cursor.  Using that as a `after=` placeholder to force the behavior.
```
> gh api "/enterprises/ENT/dependabot/alerts" --include
HTTP/2.0 200 OK
...
Link: https://api.github.com/enterprises/ENT/dependabot/alerts?per_page=1&page=2; rel="next", https://api.github.com/enterprises/ENT/dependabot/alerts?per_page=1&page=104697; rel="last"
```